### PR TITLE
Add Kustomize base manifests for GitOps deployment

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tangerine-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tangerine-frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 33%
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tangerine-frontend
+    spec:
+      containers:
+        - name: tangerine-frontend
+          image: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/tangerine/tangerine-frontend
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities: {}
+            privileged: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: tangerine-frontend
+      app.kubernetes.io/part-of: tangerine

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tangerine-frontend
+  labels:
+    app.kubernetes.io/name: tangerine-frontend
+spec:
+  selector:
+    app.kubernetes.io/name: tangerine-frontend
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000


### PR DESCRIPTION
Adds `deploy/base/` with standard Kubernetes manifests to enable ArgoCD-based GitOps deployment via the `hcm-eng-prod-cd` repository.
### Changes
- `deploy/base/kustomization.yaml` — base kustomization entry point
- `deploy/base/deployment.yaml` — converted from `openshift/template.yaml` (removed OpenShift Template parameter syntax, pinned image name without tag)
- `deploy/base/service.yaml` — converted from `openshift/template.yaml`
### Why
The existing `openshift/template.yaml` uses OpenShift Template parameter syntax (`${IMAGE}`, `${CPU_LIMIT}`, etc.) which is incompatible with Kustomize. The new `deploy/base/` provides standard K8s manifests that can be remotely referenced by the GitOps CD repo:
```yaml
resources:
  - https://github.com/RedHatInsights/tangerine-frontend//deploy/base?ref=main
 ```
 Environment-specific configuration (image tags, namespace, Route) is managed via overlays in hcm-eng-prod-cd.
 https://gitlab.cee.redhat.com/hcm-gitops/hcm-eng-prod-cd/-/merge_requests/2
 
 SDCICD-1778
 
 Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)